### PR TITLE
Remove nil from fileTypes

### DIFF
--- a/src/colorTokens.js
+++ b/src/colorTokens.js
@@ -93,7 +93,7 @@ const exportColors = (selectedLayers, type, format, naming) => {
     }else{
 
 
-      let fileTypes = NSArray.arrayWithArray([values[type].filetype, nil]);
+      let fileTypes = NSArray.arrayWithArray([values[type].filetype]);
       let savePanel = NSSavePanel.savePanel()
 
       

--- a/src/exportTokens.js
+++ b/src/exportTokens.js
@@ -96,7 +96,7 @@ const exportTokens = (selectedLayers, type) => {
     }else{
 
 
-      let fileTypes = NSArray.arrayWithArray([values[type].filetype, nil]);
+      let fileTypes = NSArray.arrayWithArray([values[type].filetype]);
       let savePanel = NSSavePanel.savePanel()
 
       savePanel.setAllowedFileTypes(fileTypes)

--- a/src/spacingTokens.js
+++ b/src/spacingTokens.js
@@ -74,7 +74,7 @@ const exportTextstyles = (selectedLayers, type, format, naming, units) => {
 
   const selectedCount = selectedLayers.length;
 
-  let fileTypes = NSArray.arrayWithArray([values[type].filetype, nil]);
+  let fileTypes = NSArray.arrayWithArray([values[type].filetype]);
 
   let savePanel = NSSavePanel.savePanel()
   //savePanel.setCanChooseDirectories(true)

--- a/src/textObjects.js
+++ b/src/textObjects.js
@@ -100,7 +100,7 @@ const exportTextstyles = (selectedLayers, type, units, naming) => {
 
   const selectedCount = selectedLayers.length;
 
-  let fileTypes = NSArray.arrayWithArray([values[type].filetype, nil]);
+  let fileTypes = NSArray.arrayWithArray([values[type].filetype]);
 
   let savePanel = NSSavePanel.savePanel()
   //savePanel.setCanChooseDirectories(true)

--- a/src/textTokens.js
+++ b/src/textTokens.js
@@ -75,7 +75,7 @@ const exportTextstyles = (selectedLayers, type, format, naming, units) => {
 
   const selectedCount = selectedLayers.length;
 
-  let fileTypes = NSArray.arrayWithArray([values[type].filetype, nil]);
+  let fileTypes = NSArray.arrayWithArray([values[type].filetype]);
 
   let savePanel = NSSavePanel.savePanel()
   //savePanel.setCanChooseDirectories(true)


### PR DESCRIPTION
I'm gonna be honest, I don't know exactly why fileTypes was structured this way or how it works but when I remove it I'm able to save token files again. 

This addresses the issue with nothing happening when exporting in issue #11 